### PR TITLE
Removing hard coded I2CAddress

### DIFF
--- a/src/SparkFunCCS811.cpp
+++ b/src/SparkFunCCS811.cpp
@@ -35,17 +35,13 @@ Distributed as-is; no warranty is given.
 
 //****************************************************************************//
 //
-//  LIS3DHCore functions
-//
-//  For I2C, construct LIS3DHCore myIMU(<address>);
+//  CCS811Core functions
 //
 //  Default <address> is 0x5B.
 //
 //****************************************************************************//
-CCS811Core::CCS811Core( uint8_t inputArg ) : I2CAddress(0x5B)
+CCS811Core::CCS811Core( uint8_t inputArg ) : I2CAddress(inputArg)
 {
-	I2CAddress = inputArg;
-
 }
 
 CCS811Core::status CCS811Core::beginCore(void)


### PR DESCRIPTION
Removed hard-coded I2CAddress "0x5B" from constructor which caused issues when trying to use the alternative address "0x5A".
Also, removed member assignment of I2CAddress as it is done by member initialisation list in constructor.