### PR TITLE
Correct preprocessor directive syntax

### DIFF
--- a/src/SparkFunCCS811.cpp
+++ b/src/SparkFunCCS811.cpp
@@ -58,7 +58,7 @@ CCS811Core::status CCS811Core::beginCore(void)
 #else
 #endif
 
-#ifdef (ARDUINO_ARCH_ESP32 ARDUINO_ARCH_ESP8266)
+#if defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_ESP8266)
 	Wire.setClockStretchLimit(200000);// was defautl 230 uS, now 200ms
 #else
 #endif


### PR DESCRIPTION
The previous incorrect syntax caused compilation of the library to fail:

SparkFun_CCS811_Arduino_Library\src\SparkFunCCS811.cpp:61:8: error: macro names must be identifiers
```
 #ifdef (ARDUINO_ARCH_ESP32 ARDUINO_ARCH_ESP8266)

        ^
```
Note that, after this fix, compilation for ESP32 still fails with a different error:
```
SparkFun_CCS811_Arduino_Library\src\SparkFunCCS811.cpp:62:7: error: 'class TwoWire' has no member named 'setClockStretchLimit'

  Wire.setClockStretchLimit(200000);// was defautl 230 uS, now 200ms

       ^
```
From https://github.com/espressif/arduino-esp32/issues/81, it's not clear whether there are plans to ever add the `setClockStretchLimit` function for ESP32. Perhaps @LGKev would care to comment on whether there is a good reason to call this function when compiling for ESP32.

Fixes https://github.com/sparkfun/SparkFun_CCS811_Arduino_Library/issues/9

CC: @bfaliszek