### PR TITLE
Add Arduino.h to library header file

### DIFF
--- a/src/SparkFunCCS811.h
+++ b/src/SparkFunCCS811.h
@@ -27,6 +27,7 @@ Distributed as-is; no warranty is given.
 #ifndef __CCS811_H__
 #define __CCS811_H__
 
+#include "Arduino.h"
 #include "stdint.h"
 #include <Wire.h>
 


### PR DESCRIPTION
This PR fixes https://github.com/sparkfun/SparkFun_CCS811_Arduino_Library/issues/24 by simply adding `Arduino.h` file to the header of the library.

This allows to compile with new Arduino SAMD Cores (>=1.8.12, tested)  and potentially other Cores (not tested).
